### PR TITLE
PSSA (Settings): Add Exclude Rules PSUseSingularNouns

### DIFF
--- a/.vscode/PSScriptAnalyzerSettings.psd1
+++ b/.vscode/PSScriptAnalyzerSettings.psd1
@@ -1,5 +1,6 @@
 @{
     ExcludeRules = @(
-        'PSUseToExportFieldsInManifest'
+        'PSUseToExportFieldsInManifest',
+        'PSUseSingularNouns'
     )
 }


### PR DESCRIPTION
Yes, use plural noun is bad idea....